### PR TITLE
Fix: get only wirst word in metric name

### DIFF
--- a/src/rendering.js
+++ b/src/rendering.js
@@ -141,7 +141,7 @@ export default function link(scope, elem, attrs, ctrl) {
       var lastMetrics = _.chain(sat)
         .get('lastMetrics', [])
         .map(function (m) { 
-        return '<b>' + m.label + ':</b> ' + m.value;
+        return '<b>' + m.label.split(" ")[0] + ':</b> ' + m.value;
       })
       .join('<br>')
       .value();


### PR DESCRIPTION
Первое слово считается за название метрики в выражении:

```sql
$columns(
    'psr sat=%sat',
    any(psr) g)
FROM $table
WHERE sat IN ($satvis)
```
Т.к., в коде `m.label == "psr sat=%sat"`, можно использовать только первое слово для отображения.